### PR TITLE
Fix CSV export encoding for non-GBK characters

### DIFF
--- a/ExcelFileCtrl.py
+++ b/ExcelFileCtrl.py
@@ -17,7 +17,7 @@ class MyWorkSheet(Worksheet):
         self.useMultiLine = useMultiLine
         self.useMacro = useMacro
         if outputCSV == True:
-            self.csvfile = open(name + '.csv', 'w', newline='')
+            self.csvfile = open(name + '.csv', 'w', newline='', encoding='utf-8-sig')
             self.csvSheet = csv.writer(self.csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
         else:
             self.csvSheet = None

--- a/code_1/ExcelFileCtrl.py
+++ b/code_1/ExcelFileCtrl.py
@@ -15,7 +15,7 @@ class MyWorkSheet(Worksheet):
         self.useMultiLine = useMultiLine
         self.useMacro = useMacro
         if outputCSV == True:
-            self.csvfile = open(name + '.csv', 'w', newline='')
+            self.csvfile = open(name + '.csv', 'w', newline='', encoding='utf-8-sig')
             self.csvSheet = csv.writer(self.csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
         else:
             self.csvSheet = None


### PR DESCRIPTION
## Summary
- open generated CSV files with UTF-8 encoding so wide characters such as Japanese middle dots can be written safely
- apply the same encoding fix to the duplicated ExcelFileCtrl helper used by other tools

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9d86423c83279b56c0281347edc5