### PR TITLE
Fix CSV writer encoding for US BLF export

### DIFF
--- a/ExcelFileCtrl.py
+++ b/ExcelFileCtrl.py
@@ -2,6 +2,7 @@ import xlsxwriter
 from xlsxwriter.worksheet import Worksheet
 from xlsxwriter.format import Format
 import csv
+import codecs
 from GlobalVar import getProgramDir
 import io  # <-- ioライブラリをインポート
 
@@ -12,15 +13,31 @@ class MyWorkSheet(Worksheet):
         self.useMultiLine = False
         self.useMacro = False
         self.onlyOutputCSV = False
+        self._csv_raw_file = None
 
     def init(self, name, workbook, useMultiLine, useMacro, outputCSV):
         self.useMultiLine = useMultiLine
         self.useMacro = useMacro
         if outputCSV == True:
-            self.csvfile = open(name + '.csv', 'w', newline='', encoding='utf-8-sig')
-            self.csvSheet = csv.writer(self.csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+            raw_csv = open(name + '.csv', 'wb')
+            raw_csv.write(codecs.BOM_UTF8)
+            self._csv_raw_file = raw_csv
+            self.csvfile = io.TextIOWrapper(
+                raw_csv,
+                encoding='utf-8',
+                newline='',
+                write_through=True,
+            )
+            self.csvSheet = csv.writer(
+                self.csvfile,
+                delimiter=',',
+                quotechar='"',
+                quoting=csv.QUOTE_MINIMAL,
+            )
         else:
             self.csvSheet = None
+            self.csvfile = None
+            self._csv_raw_file = None
         self.csvSheetRowBuffer = []
         self.csvSheetLastRowIndex = 0
 
@@ -113,7 +130,10 @@ class MyWorkSheet(Worksheet):
         if self.csvSheet != None:
             if len(self.csvSheetRowBuffer) > 0:
                 self.csvSheet.writerow(self.csvSheetRowBuffer)
-            self.csvfile.close()
+            self.csvfile.flush()
+            self.csvfile.detach()
+            if self._csv_raw_file is not None:
+                self._csv_raw_file.close()
 
     def cellFormats(self, name):
         if name in self.formatDic:


### PR DESCRIPTION
## Summary
- force the worksheet CSV writer to always emit UTF-8 with BOM so US profiles no longer fail with GBK encoding errors
- mirror the same CSV output changes in the legacy `code_1` module

## Testing
- not run (xlsxwriter dependency is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dba23062788327a3b29a0045a30369