### PR TITLE
Fix CSV parsing to preserve profile identifiers

### DIFF
--- a/code_3_run.py
+++ b/code_3_run.py
@@ -601,7 +601,9 @@ def convert_profile_message_file(
                     "Profile_info_2",
                 ],
                 encoding=enc,
-                dtype="object",
+                dtype=str,
+                keep_default_na=False,
+                na_filter=False,
                 engine="python",
             )
             used_encoding = enc


### PR DESCRIPTION
## Summary
- configure `pandas.read_csv` to keep all values as plain strings so blank rows can be filled correctly
- disable automatic NA detection to avoid precision loss on large identifier columns when generating CSV outputs

## Testing
- not run (environment lacks pandas dependency)

------
https://chatgpt.com/codex/tasks/task_e_68dc04a89f9c8327a432c494dfa8c207